### PR TITLE
Refactored code to write run id to execution file

### DIFF
--- a/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/NonDexMojo.java
+++ b/nondex-maven-plugin/src/main/java/edu/illinois/nondex/plugin/NonDexMojo.java
@@ -34,6 +34,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
@@ -65,6 +66,11 @@ public class NonDexMojo extends AbstractNonDexMojo {
     private List<NonDexSurefireExecution> executions = new LinkedList<>();
     private ArrayList<CleanSurefireExecution> executionsWithoutShuffling =
             new ArrayList<CleanSurefireExecution>();
+    private Path runFilePath = null;
+
+    public void setFilePath(Path value) {
+        this.runFilePath = this.runFilePath == null ? value : this.runFilePath;
+    }
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
@@ -92,6 +98,7 @@ public class NonDexMojo extends AbstractNonDexMojo {
                                 .toString(),
                             this.surefire, this.originalArgLine, this.mavenProject,
                             this.mavenSession, this.pluginManager);
+            setFilePath(execution.getConfiguration().getRunFilePath());
             this.executions.add(execution);
             allExceptions = this.executeSurefireExecution(allExceptions, execution);
             this.writeCurrentRunInfo(execution);
@@ -262,8 +269,7 @@ public class NonDexMojo extends AbstractNonDexMojo {
 
     private void writeCurrentRunInfo(CleanSurefireExecution execution) {
         try {
-            // TODO(gyori): This is quite ugly, you grabbing here the first from a list to establish a run id.
-            Files.write(this.executions.get(0).getConfiguration().getRunFilePath(),
+            Files.write(this.runFilePath,
                         (execution.getConfiguration().executionId + String.format("%n")).getBytes(),
                          StandardOpenOption.CREATE, StandardOpenOption.APPEND);
         } catch (IOException ex) {


### PR DESCRIPTION
**Description**
Every  `NonDexSurefireExecution` has an `executionId` and a `runFilePath`. The `runFilePath` is configured based on the `executionId` [link](https://github.com/TestingResearchIllinois/NonDex/blob/master/nondex-common/src/main/java/edu/illinois/nondex/common/Configuration.java#L213). The `NonDexMojo` class consists of a `List<NonDexSurefireExecution>` called `executions`. Within the `execute` method, this list is populated.

For each `execution` in this list , the `executionId` of the corresponding execution is being appended to a file whose path is the `runFilePath` of the first member of this list. This base path information is not stored anywhere and fetched from the first element for writing each `executionId`. This is the portion of the code being refactored as part of this Pull request.

**Fix**
The base path is being used across functions of the class and therefore, It is necessary to extract it as a member of the `NonDexMojo` class. This allows future configurations of this base path with a single change. This member is extracted within `execute` function and is used in the `writeCurrentRunInfo` method.

**Verification**
- The fix was verified by checking that a single `<executionId>.run` file was created within the `.nondex` directory, containing all the `executionIds` of the run, when we ran mvn test on a sample repository

`mvn -pl pushy edu.illinois:nondex-maven-plugin:2.1.7-SNAPSHOT:nondex -Dtest=com.eatthepath.pushy.apns.server.TokenAuthenticationValidatingPushNotificationHandlerTest#testHandleNotificationWithWithExpiredAuthenticationToken`

- The number of generated files were verified by [integration test](https://github.com/TestingResearchIllinois/NonDex/blob/master/nondex-maven-plugin/src/it/simple-it/verify.groovy#L7) in Nondex repository