### PR TITLE
Fixed TODO to improve unordered string comparision

### DIFF
--- a/nondex-test/src/test/java/edu/illinois/nondex/core/AbstractCollectionTest.java
+++ b/nondex-test/src/test/java/edu/illinois/nondex/core/AbstractCollectionTest.java
@@ -29,6 +29,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 package edu.illinois.nondex.core;
 
+import java.util.Arrays;
+
 import edu.illinois.nondex.shuffling.ControlNondeterminism;
 
 import org.junit.Assert;
@@ -46,7 +48,7 @@ public abstract class AbstractCollectionTest<T> {
             case FULL:
                 String tempStr = derived.toString();
                 Assert.assertNotEquals("FULL is improperly running", str, tempStr);
-                this.assertEqualstUnordered("Does not match permutation", str, tempStr);
+                this.assertEqualsUnordered("Does not match permutation", str, tempStr);
                 break;
             case ONE:
                 Assert.assertEquals("ONE is improperly running", str, derived.toString());
@@ -56,16 +58,19 @@ public abstract class AbstractCollectionTest<T> {
         }
     }
 
-    protected void assertEqualstUnordered(String msg, String expected, String actual) {
-        Assert.assertEquals(msg + ": " + expected + " =/= " + actual, expected.length(), actual.length());
+    private String[] trimAndSplitStrings(String msg) {
+        String trimmed = msg.substring(1, msg.length() - 1);
+        String[] elems = trimmed.split(", ");
+        return elems;
+    }
+
+    protected void assertEqualsUnordered(String msg, String expected, String actual) {
         String trimmed = expected.substring(1, expected.length() - 1);
-        String[] elems = trimmed.split(",");
-        // TODO(gyori): fix and make this more robust. It does not check duplicates, substrings, etc.
-        for (int i = 0; i < elems.length; i++) {
-            elems[i] = elems[i].trim();
-            Assert.assertTrue(msg + ": " + trimmed + " =/= " + actual, actual.contains(elems[i]));
-        }
+        String[] actualTokenized = this.trimAndSplitStrings(actual);
+        String[] expectedTokenized = this.trimAndSplitStrings(expected);
 
-
+        Arrays.sort(actualTokenized);
+        Arrays.sort(expectedTokenized);
+        Assert.assertArrayEquals(msg + ": " + trimmed + " =/= " + actual, expectedTokenized, actualTokenized);
     }
 }

--- a/nondex-test/src/test/java/edu/illinois/nondex/core/ConcurrentHashMapTest.java
+++ b/nondex-test/src/test/java/edu/illinois/nondex/core/ConcurrentHashMapTest.java
@@ -98,7 +98,7 @@ public class ConcurrentHashMapTest extends AbstractCollectionTest<ConcurrentHash
 
         Assert.assertNotEquals("You are likely running an unchanged JVM",
                 "{0, 2, 3, 4, 5, 6, 7, 8, 9}", keySet.toString());
-        this.assertEqualstUnordered("The strings are not a permutation of each other",
+        this.assertEqualsUnordered("The strings are not a permutation of each other",
                 "{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}", keySet.toString());
 
     }
@@ -127,7 +127,7 @@ public class ConcurrentHashMapTest extends AbstractCollectionTest<ConcurrentHash
 
         Assert.assertNotEquals("You are likely running an unchanged JVM",
                 "{0, 2, 3, 4, 5, 6, 7, 8, 9}", values.toString());
-        this.assertEqualstUnordered("The strings are not a permutation of each other",
+        this.assertEqualsUnordered("The strings are not a permutation of each other",
                 "{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}", values.toString());
 
         String str = values.toString();
@@ -141,7 +141,7 @@ public class ConcurrentHashMapTest extends AbstractCollectionTest<ConcurrentHash
 
         Assert.assertNotEquals("You are likely running an unchanged JVM",
                 "{0=0, 2=2, 3=3, 4=4, 5=5, 6=6, 7=7, 8=8, 9=9}", entrySet.toString());
-        this.assertEqualstUnordered("The strings are not a permutation of each other",
+        this.assertEqualsUnordered("The strings are not a permutation of each other",
                 "{0=0, 1=1, 2=2, 3=3, 4=4, 5=5, 6=6, 7=7, 8=8, 9=9}", entrySet.toString());
     }
 
@@ -161,7 +161,7 @@ public class ConcurrentHashMapTest extends AbstractCollectionTest<ConcurrentHash
 
         Assert.assertNotEquals("You are likely running an unchanged JVM",
                 "{0, 2, 3, 4, 5, 6, 7, 8, 9}", enumerated.toString());
-        this.assertEqualstUnordered("The collection does not containt the elements asserted",
+        this.assertEqualsUnordered("The collection does not containt the elements asserted",
                 "{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}", enumerated.toString());
     }
 }

--- a/nondex-test/src/test/java/edu/illinois/nondex/core/HashMapTest.java
+++ b/nondex-test/src/test/java/edu/illinois/nondex/core/HashMapTest.java
@@ -89,7 +89,7 @@ public class HashMapTest extends AbstractCollectionTest<Map<Integer, Integer>> {
 
         String str = map.toString();
         Assert.assertNotEquals("You are not running FULL nondex", str, map.toString());
-        this.assertEqualstUnordered("The strings are not a permutation of each other", str, map.toString());
+        this.assertEqualsUnordered("The strings are not a permutation of each other", str, map.toString());
     }
 
     @Test
@@ -99,7 +99,7 @@ public class HashMapTest extends AbstractCollectionTest<Map<Integer, Integer>> {
 
         Assert.assertNotEquals("You are likely running an unchanged JVM",
                 "{0, 2, 3, 4, 5, 6, 7, 8, 9}", keySet.toString());
-        this.assertEqualstUnordered("The strings are not a permuation of each other",
+        this.assertEqualsUnordered("The strings are not a permuation of each other",
                 "{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}", keySet.toString());
 
     }
@@ -119,7 +119,7 @@ public class HashMapTest extends AbstractCollectionTest<Map<Integer, Integer>> {
 
         Assert.assertNotEquals("You are likely running an unchanged JVM",
                 "{0, 2, 3, 4, 5, 6, 7, 8, 9}", values.toString());
-        this.assertEqualstUnordered("The strings are not a permutation of each other",
+        this.assertEqualsUnordered("The strings are not a permutation of each other",
                 "{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}", values.toString());
     }
 
@@ -130,7 +130,7 @@ public class HashMapTest extends AbstractCollectionTest<Map<Integer, Integer>> {
 
         Assert.assertNotEquals("You are likely running an unchanged JVM",
                 "{0, 2, 3, 4, 5, 6, 7, 8, 9}", values.toString());
-        this.assertEqualstUnordered("The strings are not a permuation of each other",
+        this.assertEqualsUnordered("The strings are not a permuation of each other",
                 "{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}", values.toString());
 
         String str = values.toString();
@@ -144,8 +144,14 @@ public class HashMapTest extends AbstractCollectionTest<Map<Integer, Integer>> {
 
         Assert.assertNotEquals("You are likely running an unchanged JVM",
                 "{0=0, 2=2, 3=3, 4=4, 5=5, 6=6, 7=7, 8=8, 9=9}", entrySet.toString());
-        this.assertEqualstUnordered("The strings are not a permutation of each other",
+        this.assertEqualsUnordered("The strings are not a permutation of each other",
                 "{0=0, 1=1, 2=2, 3=3, 4=4, 5=5, 6=6, 7=7, 8=8, 9=9}", entrySet.toString());
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testAssertEqualsUnorderedFailsWithDuplicates() {
+        this.assertEqualsUnordered("the strings are not a permutation of each other",
+            "{0=0, 0=0, 1=1, 2=2, 3=3}", "{0=0, 1=1, 2=2, 3=3}");
     }
 
     @Test


### PR DESCRIPTION
### Setup
- Java version: 11.0.20.1
- Maven version: Apache Maven 3.6.3

### Description
This PR addresses the following TODO in the test utility function:

https://github.com/kavvya97/NonDex/blob/8843b436802af4a0850f63d6ae0f231164dafe78/nondex-test/src/test/java/edu/illinois/nondex/core/AbstractCollectionTest.java#L63

The function `assertEqualstUnordered` checks whether the contents of two data structures are equal without considering the order of the elements. Currently, it converts the content of both structures into string form and checks if the strings have the same length. If they do, it tokenizes one of them by splitting on commas to obtain multiple `key=value` elements. Then, it checks if each element is present in the other string as a substring.

https://github.com/kavvya97/NonDex/blob/8843b436802af4a0850f63d6ae0f231164dafe78/nondex-test/src/test/java/edu/illinois/nondex/core/AbstractCollectionTest.java#L66

However, this approach doesn't account for duplicates or substrings in the data structures. For example, consider the two strings:
`"{0=0, 0=0, 1=1, 2=2}"` and `"{0=0, 1=1, 2=2, 1=1}"`. These two strings should not be considered equal, but the current test considers them equal.

### Fix
Both strings are tokenized in the same manner as described above. The tokenized strings are then sorted and checked for equality. This approach will detect cases where duplicates differ between the two strings.

### Verification
- The fix did not introduce any regressions in existing tests that use this utility.
- An additional test was implemented to handle corner cases, such as the example mentioned above. The existing implementation of `assertEqualstUnordered` fails this test.